### PR TITLE
fix api_kwargs (delay_in_seconds) in Task.later()

### DIFF
--- a/django_cloud_tasks/tasks.py
+++ b/django_cloud_tasks/tasks.py
@@ -79,7 +79,7 @@ class Task(metaclass=TaskMeta):
 
         return self._send(
             task_kwargs=kwargs,
-            api_kwargs=delay_in_seconds,
+            api_kwargs={"delay_in_seconds": delay_in_seconds},
         )
 
     def _send(self, task_kwargs, api_kwargs=None):


### PR DESCRIPTION
It was probably a typo - works for me now.