### PR TITLE
[MSN-1990] Use env var to limit eta task

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Additionally, you can configure with more settings or environment variables:
 - `DJANGO_CLOUD_TASKS_SUBSCRIBERS_URL_NAME`: Django URL-name that process Subscribers. We provide a view for that, but if you want to create your own, set this value. Default: `subscriptions-endpoint`.
 - `DJANGO_CLOUD_TASKS_PROPAGATED_HEADERS`: . Default: `["traceparent"]`.
 - `DJANGO_CLOUD_TASKS_PROPAGATED_HEADERS_KEY`: when propagating headers in PubSub, use a key to store the values in the Message data. Default: `_http_headers`.
+- `DJANGO_CLOUD_TASKS_MAXIMUM_ETA_TASK`: maximum time in seconds to schedule a task in the future. Default: `86400`.
 
 ## On Demand Task
 

--- a/django_cloud_tasks/apps.py
+++ b/django_cloud_tasks/apps.py
@@ -30,6 +30,7 @@ class DjangoCloudTasksAppConfig(AppConfig):
         self.delimiter = self._fetch_config(name="DELIMITER", default="--")
         self.eager = self._fetch_config(name="EAGER", default=False)
         self.tasks_url_name = self._fetch_config(name="URL_NAME", default="tasks-endpoint")
+        self.tasks_max_eta = self._fetch_config(name="MAXIMUM_ETA_TASK", default=60 * 60 * 24)  # 1 day
         self.subscribers_url_name = self._fetch_config(name="SUBSCRIBERS_URL_NAME", default="subscriptions-endpoint")
 
         self.subscribers_max_retries = self._fetch_config(name="SUBSCRIBER_MAX_RETRIES", default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-google-cloud-tasks"
-version = "2.15.0"
+version = "2.16.0"
 description = "Async Tasks with HTTP endpoints"
 authors = ["Joao Daher <joao@daher.dev>"]
 packages = [

--- a/sample_project/sample_app/tests/tests_tasks/tests_tasks.py
+++ b/sample_project/sample_app/tests/tests_tasks/tests_tasks.py
@@ -224,6 +224,16 @@ class TasksTest(PatchOutputAndAuthMixin, SimpleTestCase):
 
         push.assert_not_called()
 
+    def test_task_later_delay_exceeds_maximum_eta(self):
+        task_kwargs = dict(price=30, quantity=4, discount=0.2)
+        excessive_delay = int(60 * 60 * 24 * 2)  # 2 days
+
+        with self.assertRaises(ValueError) as context:
+            tasks.CalculatePriceTask.later(eta=excessive_delay, task_kwargs=task_kwargs)
+
+        max_eta_task = get_config("tasks_max_eta")
+        self.assertEqual(f"Invalid delay time {excessive_delay}, maximum is {max_eta_task}", str(context.exception))
+
     def test_singleton_client_on_task(self):
         # we have a singleton if it calls the same task twice
         with (


### PR DESCRIPTION
## Context
In our current implementation of the later method, we do not have a mechanism to enforce a maximum allowable delay time for task scheduling. This can lead to tasks being scheduled far into the future, which might not be desirable or could cause unexpected behavior in our application. To address this, we need to introduce a check that ensures the delay time does not exceed a specified maximum value.

## Issues
https://nilosaude.atlassian.net/browse/MSN-1989

## Solution
This pull request introduces a new check within the later method to enforce a maximum allowable delay time for task scheduling. The maximum delay time is configurable through the MAXIMUM_ETA_TASK setting in Django. If the MAXIMUM_ETA_TASK setting is defined and the calculated delay exceeds this value, the method raises a ValueError indicating the delay time is invalid.
By adding this check, we ensure that the task scheduling respects the maximum delay time configured in our settings, thereby preventing tasks from being scheduled too far into the future.