### PR TITLE
feat: allow custom HTTP status codes when using DiscardTaskException

### DIFF
--- a/django_cloud_tasks/exceptions.py
+++ b/django_cloud_tasks/exceptions.py
@@ -10,4 +10,11 @@ class TaskNotFound(Exception):
         super().__init__(message)
 
 
-class DiscardTaskException(Exception): ...
+class DiscardTaskException(Exception):
+    default_http_status_code: int = 202
+    default_http_status_reason: str | None = None  # only needed for custom HTTP status codes
+
+    def __init__(self, *args, http_status_code: int | None = None, http_status_reason: str | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.http_status_code = http_status_code or self.default_http_status_code
+        self.http_status_reason = http_status_reason or self.default_http_status_reason

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-google-cloud-tasks"
-version = "2.16.4"
+version = "2.17.0"
 description = "Async Tasks with HTTP endpoints"
 authors = ["Joao Daher <joao@daher.dev>"]
 packages = [

--- a/sample_project/sample_app/tests/tests_tasks/tests_tasks.py
+++ b/sample_project/sample_app/tests/tests_tasks/tests_tasks.py
@@ -50,17 +50,18 @@ class TasksTest(PatchOutputAndAuthMixin, SimpleTestCase):
     def test_registered_tasks(self):
         expected_tasks = {
             "CalculatePriceTask",
+            "DummyRoutineTask",
+            "ExposeCustomHeadersTask",
             "FailMiserablyTask",
+            "FindPrimeNumbersTask",
+            "NonCompliantTask",
             "OneBigDedicatedTask",
+            "ParentCallingChildTask",
+            "PublishPersonTask",
             "RoutineExecutorTask",
+            "RoutineReverterTask",
             "SayHelloTask",
             "SayHelloWithParamsTask",
-            "DummyRoutineTask",
-            "RoutineReverterTask",
-            "ParentCallingChildTask",
-            "ExposeCustomHeadersTask",
-            "PublishPersonTask",
-            "NonCompliantTask",
         }
         self.assertEqual(expected_tasks, set(self.app_config.on_demand_tasks))
 
@@ -89,6 +90,7 @@ class TasksTest(PatchOutputAndAuthMixin, SimpleTestCase):
             tasks.SayHelloTask,
             tasks.SayHelloWithParamsTask,
             tasks.PublishPersonTask,
+            tasks.FindPrimeNumbersTask,
             tasks.DummyRoutineTask,
             another_app_tasks.deep_down_tasks.one_dedicated_task.OneBigDedicatedTask,
             another_app_tasks.deep_down_tasks.one_dedicated_task.NonCompliantTask,


### PR DESCRIPTION
To prevent a Google Cloud Task from being retried, it is necessary to return a status code in the 200-299 range. The mechanism django_cloud_tasks currently offers for this is raising `DiscardTaskException`, but in this case the status code will always be HTTP 202 (Accepted). When we want to discard a task due to an unrecoverable error, this HTTP status code offers no good semantics. Also, from a monitoring perspective, simply discarding a task (perhaps it is no longer needed - for example: attempting to delete something that has already been deleted) and discarding a task due to an unrecoverable error (for example: the task input is invalid) are two different things, but we have no means to differentiate them if the status code is always the same.

This PR adds a bit of flexibility, allowing DiscardTaskException to receive an HTTP status code / HTTP status reason phrase as either constructor arguments, or by subclassing it and overriding default_http_status_code / default_http_status_reason.

This PR won't add a built-in "UnrecoverableTaskException" base class because there is no HTTP 2xx status code (even when considering augmented standards) to reflect this scenario, so we will leave it up to each project that uses django-cloud-tasks to configure this setup, as it will be project-specific by definition.