### PR TITLE
fix: subscriber initialization should not assume all tasks follow the…

### DIFF
--- a/django_cloud_tasks/apps.py
+++ b/django_cloud_tasks/apps.py
@@ -196,7 +196,9 @@ class DjangoCloudTasksAppConfig(AppConfig):
             if not self.app_name:
                 return names
 
-            for subscription in client.list_subscriptions(suffix=self.app_name):
+            for subscription in client.list_subscriptions():
+                if self.domain not in subscription.push_config.push_endpoint:
+                    continue
                 subscription_id = subscription.name.rsplit("subscriptions/", 1)[-1]
                 task_name = subscription.push_config.push_endpoint.rsplit("/", 1)[-1]
                 names.append((task_name, subscription_id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-google-cloud-tasks"
-version = "2.17.0"
+version = "2.18.0.rc1"
 description = "Async Tasks with HTTP endpoints"
 authors = ["Joao Daher <joao@daher.dev>"]
 packages = [


### PR DESCRIPTION
… default naming convention

I've noticed, at Nilo, that all our deploys think the catalog subscriber has not been added yet:

```
make prd-register_subscriptions
./almanac_api/manage.py initialize_subscribers
Successfully initialized 3 subscribers to domain https://almanac-api-xxxxxxxxxxxx.us-east1.run.app
- [+] CatalogAutoGeneratorSubscriber
- [~] CareProviderSubscriberTask
- [~] RefereeInfoSubscriberTask
```

That is because this subscription uses a target HTTP endpoint that does not follow the default conventions. django-cloud-tasks allow customizing this, so it is not like the library is being used in an unexpected way.

The problem, however, is not adding the subscriber, but rather removing it: since it is never found, once it is no longer offered, the subscription won't be erased.

This commits change the intiailize_subscribers strategy so that it matches subscriptions by domain, and not by name