### PR TITLE
feat: add configurable retry policy for task enqueuing

### DIFF
--- a/django_cloud_tasks/apps.py
+++ b/django_cloud_tasks/apps.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.utils.module_loading import module_has_submodule
 from gcp_pilot.pubsub import CloudSubscriber
 from gcp_pilot.scheduler import CloudScheduler
-
+from google.api_core.retry import retry_base
 from django_cloud_tasks import exceptions
 
 PREFIX = "DJANGO_CLOUD_TASKS_"
@@ -46,6 +46,20 @@ class DjangoCloudTasksAppConfig(AppConfig):
         )
         self.propagated_headers_key = self._fetch_str_config(
             name="PROPAGATED_HEADERS_KEY", default=DEFAULT_PROPAGATION_HEADERS_KEY
+        )
+
+        self.enqueue_retry_exceptions = self._fetch_list_config(name="ENQUEUE_RETRY_EXCEPTIONS", default=None)
+        self.enqueue_retry_initial = self._fetch_float_config(
+            name="ENQUEUE_RETRY_INITIAL", default=retry_base._DEFAULT_INITIAL_DELAY
+        )
+        self.enqueue_retry_maximum = self._fetch_float_config(
+            name="ENQUEUE_RETRY_MAXIMUM", default=retry_base._DEFAULT_MAXIMUM_DELAY
+        )
+        self.enqueue_retry_multiplier = self._fetch_float_config(
+            name="ENQUEUE_RETRY_MULTIPLIER", default=retry_base._DEFAULT_DELAY_MULTIPLIER
+        )
+        self.enqueue_retry_deadline = self._fetch_float_config(
+            name="ENQUEUE_RETRY_DEADLINE", default=retry_base._DEFAULT_DEADLINE
         )
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-google-cloud-tasks"
-version = "2.19.0"
+version = "2.20.0"
 description = "Async Tasks with HTTP endpoints"
 authors = [
     {name = "Joao Daher", email = "joao@daher.dev"},

--- a/sample_project/sample_app/tasks.py
+++ b/sample_project/sample_app/tasks.py
@@ -150,3 +150,17 @@ class MyMetadata(TaskMetadata): ...
 
 
 class MyUnsupportedMetadata: ...
+
+
+class RetryEnqueueTask(Task):
+    enqueue_retry_exceptions = [
+        "google.api_core.exceptions.ServiceUnavailable",
+        "google.api_core.exceptions.InternalServerError",
+    ]
+    enqueue_retry_initial = 0.1
+    enqueue_retry_maximum = 10.0
+    enqueue_retry_multiplier = 1.3
+    enqueue_retry_deadline = 20.0
+
+    def run(self, **kwargs):
+        pass


### PR DESCRIPTION
## Problem

When creating tasks using the Cloud Tasks API, transient errors (network instability, service unavailable responses, etc.) can cause task creation to fail silently. Since there is no automatic retry for the API calls that enqueue tasks, this leads to several critical issues:

- **Data inconsistency**: Tasks triggered by model signals might never be created
- **Broken workflows**: Multi-step pipelines can stall permanently when a step fails to enqueue
- **Message loss**: Publisher tasks might fail to publish critical messages
- **Silent failures**: These failures often occur without raising visible errors in the main operation

It's important to note that the retry configuration in Cloud Tasks queues only applies *after* a task has been successfully created. It doesn't cover failures during the task creation API call itself.

## Solution

This PR adds a configurable retry mechanism for task creation using `google.api_core.retry.Retry`, implementing an exponential backoff strategy for transient API errors.

The implementation:

1. Adds new configuration options in `DjangoCloudTasksAppConfig` for retry parameters:
   - `ENQUEUE_RETRY_EXCEPTIONS`: Exception classes that trigger retries
   - `ENQUEUE_RETRY_INITIAL`: Initial retry delay (seconds)
   - `ENQUEUE_RETRY_MAXIMUM`: Maximum retry delay (seconds)
   - `ENQUEUE_RETRY_MULTIPLIER`: Delay multiplier between retries
   - `ENQUEUE_RETRY_DEADLINE`: Maximum total retry time (seconds)

2. Adds class-level attributes to override these settings per task class

3. Implements a new `enqueue_retry_policy` method that creates and configures `google.api_core.retry.Retry` objects

4. Seamlessly integrates retry with the `push` method (and by extension with `asap`, `later` and `until`)

5. Includes comprehensive test coverage

## Usage

Global configuration in Django settings:
```python
# settings.py
DJANGO_CLOUD_TASKS_ENQUEUE_RETRY_EXCEPTIONS = "google.api_core.exceptions.ServiceUnavailable,google.api_core.exceptions.InternalServerError"
DJANGO_CLOUD_TASKS_ENQUEUE_RETRY_INITIAL = 0.1  # seconds
DJANGO_CLOUD_TASKS_ENQUEUE_RETRY_MAXIMUM = 10.0  # seconds
DJANGO_CLOUD_TASKS_ENQUEUE_RETRY_MULTIPLIER = 1.3
DJANGO_CLOUD_TASKS_ENQUEUE_RETRY_DEADLINE = 20.0  # seconds
```

Task-specific configuration:
```python
class MyTask(Task):
    enqueue_retry_exceptions = [
        "google.api_core.exceptions.ServiceUnavailable",
        "google.api_core.exceptions.InternalServerError",
    ]
    enqueue_retry_initial = 0.1
    enqueue_retry_maximum = 10.0
    enqueue_retry_multiplier = 1.3
    enqueue_retry_deadline = 20.0
    
    def run(self, **kwargs):
        # Task implementation
        pass
```

This enhancement provides fine-grained control over retry behavior during task enqueuing, helping to handle temporary API failures gracefully without requiring additional application-level retry logic.

## Related PRs
- [gcp-pilot PR #67](https://github.com/flamingo-run/gcp-pilot/pull/67)
