### PR TITLE
fix: default dispatch and execution numbers to 0 for Cloud Scheduler Tasks

### DIFF
--- a/django_cloud_tasks/tasks/task.py
+++ b/django_cloud_tasks/tasks/task.py
@@ -51,12 +51,12 @@ class TaskMetadata:
         if (attempt_str := headers.get(f"{cloud_tasks_prefix}Taskexecutioncount")) is not None:
             execution_number = int(attempt_str)
         else:
-            execution_number = None
+            execution_number = 0
 
         if (retry_str := headers.get(f"{cloud_tasks_prefix}Taskretrycount")) is not None:
             dispatch_number = int(retry_str)
         else:
-            dispatch_number = None
+            dispatch_number = 0
 
         if eta_epoch := headers.get(f"{cloud_tasks_prefix}Tasketa"):
             eta = datetime.fromtimestamp(int(eta_epoch.split(".")[0]), tz=timezone.utc)

--- a/sample_project/sample_app/tests/tests_tasks/tests_tasks.py
+++ b/sample_project/sample_app/tests/tests_tasks/tests_tasks.py
@@ -418,6 +418,28 @@ class TestTaskMetadata(TestCase):
         self.assertEqual("wizard-api--LevitationTask", metadata.cloud_scheduler_job_name)
         self.assertEqual(datetime(2023, 11, 3, 15, 27, 0, tzinfo=UTC), metadata.cloud_scheduler_schedule_time)
 
+    def test_create_from_cloud_scheduler_headers_without_cloud_tasks_headers(self):
+        headers = {
+            "X-Cloudtasks-Tasketa": str(self.some_date.timestamp()),
+            "X-Cloudtasks-Projectname": "wizard-project",
+            "X-Cloudtasks-Queuename": "wizard-queue",
+            "X-Cloudtasks-Taskname": "hp-1234567",
+            "X-Cloudscheduler": "true",
+            "X-Cloudscheduler-Scheduletime": "2023-11-03T08:27:00-07:00",
+            "X-Cloudscheduler-Jobname": "wizard-api--LevitationTask",
+        }
+        metadata = TaskMetadata.from_headers(headers=headers)
+
+        self.assertEqual(0, metadata.dispatch_number)
+        self.assertEqual(0, metadata.execution_number)
+        self.assertEqual(1, metadata.attempt_number)
+        self.assertTrue(metadata.first_attempt)
+        self.assertTrue(metadata.is_cloud_scheduler)
+
+        output_headers = metadata.to_headers()
+        self.assertEqual("0", output_headers["X-Cloudtasks-Taskretrycount"])
+        self.assertEqual("0", output_headers["X-Cloudtasks-Taskexecutioncount"])
+
     def test_build_headers(self):
         headers = self.sample_metadata.to_headers()
 


### PR DESCRIPTION
### Description
When a task is triggered directly by Google Cloud Scheduler, GCP does not send the `X-Cloudtasks-Taskretrycount` or `X-Cloudtasks-Taskexecutioncount` headers. 

Currently, `TaskMetadata.from_headers()` defaults these missing values to `None`. This causes two downstream bugs when a task is invoked by Cloud Scheduler:

1. **Application Crash:** Accessing `task.attempt_number` or `task.first_attempt` results in a `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'` because `dispatch_number` is `None`.
2. **Invalid Header Generation:** Generating headers via `to_headers()` produces invalid literal strings for integer fields (e.g., `"X-Cloudtasks-Taskretrycount": "None"`).

### Discovered
Discovered this whilst writing a wrapper that uses these fields for additional information on the task, as a result despite these values not being accessed in the hotpath for the periodic task, the bug is introduced. Specifically metadata.attempt_number.

### Proposed Changes
* Updated `TaskMetadata.from_headers` to default `dispatch_number` and `execution_number` to `0` (instead of `None`) when the incoming headers are missing. 
* This aligns the behavior with `build_eager()`, ensuring these fields are safely typed as integers.

### Testing
* Added a new unit test: `test_create_from_cloud_scheduler_headers_without_cloud_tasks_headers` to verify that Scheduler requests parse safely, avoid the `TypeError` on attempt properties, and generate valid integer strings when serialized back to headers.